### PR TITLE
Dockerfile: Make docker file build from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
+FROM golang:1.12 as build
+ARG user="SUSE CFCIBot"
+ARG email=ci-ci-bot@suse.de
+ADD . /eirini-loggregator-bridge
+WORKDIR /eirini-loggregator-bridge
+RUN git config --global user.name ${user}
+RUN git config --global user.email ${email}
+RUN GO111MODULE=on go mod vendor
+RUN bin/build
+
 FROM bitnami/kubectl as kubectl
 
-FROM opensuse:leap
+FROM opensuse/leap
 COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
-ADD binaries/eirini-loggregator-bridge /bin/eirini-loggregator-bridge
+COPY --from=build /eirini-loggregator-bridge/binaries/eirini-loggregator-bridge /bin/eirini-loggregator-bridge
 ENTRYPOINT ["/bin/eirini-loggregator-bridge"]
 


### PR DESCRIPTION
Make the docker file be self-contained and build the whole thing from scratch, instead of relying on having built the binaries locally ahead of time.  This makes it easier for CI to build things reliably.

This should have no effect on [eirini-bosh-release](https://github.com/cloudfoundry-community/eirini-bosh-release/blob/master/packages/eirini-loggregator-bridge/packaging) as that doesn't seem to use the Dockerfile at all.

Please let me know if I missed some CI somewhere that has been building the docker images already; it's not obvious from the repo.

To test: `docker build .` from a clean checkout (or just delete the built artifact before doing it).