### PR TITLE
Allow to read config also from environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,11 +26,11 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 
-		LogDebug("Namespace: ", fmt.Sprintf("%s", config.Namespace))
-		LogDebug("Loggregator-endpoint: ", fmt.Sprintf("%s", config.LoggregatorEndpoint))
-		LogDebug("Loggregator-ca-path: ", fmt.Sprintf("%s", config.LoggregatorCAPath))
-		LogDebug("Loggregator-cert-path: ", fmt.Sprintf("%s", config.LoggregatorCertPath))
-		LogDebug("Loggregator-key-path: ", fmt.Sprintf("%s", config.LoggregatorKeyPath))
+		LogDebug("Namespace: ", config.Namespace)
+		LogDebug("Loggregator-endpoint: ", config.LoggregatorEndpoint)
+		LogDebug("Loggregator-ca-path: ", config.LoggregatorCAPath)
+		LogDebug("Loggregator-cert-path: ", config.LoggregatorCertPath)
+		LogDebug("Loggregator-key-path: ", config.LoggregatorKeyPath)
 		LogDebug("Starting Loggregator")
 
 		err = config.Validate()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	eirinix "github.com/SUSE/eirinix"
+	"gopkg.in/yaml.v2"
 
 	configpkg "github.com/SUSE/eirini-loggregator-bridge/config"
 	. "github.com/SUSE/eirini-loggregator-bridge/logger"
@@ -18,7 +19,16 @@ import (
 var cfgFile string
 var kubeconfig string
 
-var config configpkg.ConfigType
+// See: https://github.com/spf13/viper/issues/188
+// Viper, without default config doesn't set keys, and later
+// they are not populated into config when unmarshalling
+var config configpkg.ConfigType = configpkg.ConfigType{
+	Namespace:           "default",
+	LoggregatorEndpoint: "loggregator-endpoint",
+	LoggregatorCAPath:   "loggregator-ca-path",
+	LoggregatorCertPath: "loggregator-cert-path",
+	LoggregatorKeyPath:  "loggregator-key-path",
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "eirini-loggregator-bridge",
@@ -66,31 +76,21 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "kubeconfig file path. This is optional, in cluster config will be used if not set")
 }
 
-// See: https://github.com/spf13/viper/issues/188#issuecomment-399884438
-func BindEnvs(iface interface{}, parts ...string) {
-	ifv := reflect.ValueOf(iface)
-	ift := reflect.TypeOf(iface)
-	for i := 0; i < ift.NumField(); i++ {
-		v := ifv.Field(i)
-		t := ift.Field(i)
-		tv, ok := t.Tag.Lookup("mapstructure")
-		if !ok {
-			continue
-		}
-		switch v.Kind() {
-		case reflect.Struct:
-			BindEnvs(v.Interface(), append(parts, tv)...)
-		default:
-			viper.BindEnv(strings.Join(append(parts, tv), "."))
-		}
-	}
-}
-
 func initConfig() {
 	if cfgFile != "" {
+		viper.SetConfigType("yaml")
+		emptyConfigBytes, err := yaml.Marshal(config)
+		if err != nil {
+			LogError("Can't marshal config:", err.Error())
+			os.Exit(1)
+		}
+
+		emptyConfigReader := bytes.NewReader(emptyConfigBytes)
+		viper.MergeConfig(emptyConfigReader)
+
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
-		if err := viper.ReadInConfig(); err != nil {
+		if err := viper.MergeInConfig(); err != nil {
 			LogError("Can't read config:", err.Error())
 			os.Exit(1)
 		}
@@ -98,8 +98,6 @@ func initConfig() {
 
 	viper.AutomaticEnv() // read in environment variables that match
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	BindEnvs(config)
 	viper.Unmarshal(&config)
 
 	LogDebug("Namespace: ", fmt.Sprintf("%s", config.Namespace))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	eirinix "github.com/SUSE/eirinix"
@@ -67,14 +68,18 @@ func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
-	} else {
-		LogError("You didn't specify a config file (Use --help)")
-		os.Exit(1)
+		if err := viper.ReadInConfig(); err != nil {
+			LogError("Can't read config:", err.Error())
+			os.Exit(1)
+		}
 	}
 
-	if err := viper.ReadInConfig(); err != nil {
-		LogError("Can't read config:", err.Error())
-		os.Exit(1)
-	}
 	viper.Unmarshal(&config)
+	viper.AutomaticEnv() // read in environment variables that match
+
+	LogDebug("Namespace: ", fmt.Sprintf("%s", viper.GetString("namespace")))
+	LogDebug("Loggregator-endpoint: ", fmt.Sprintf("%s", viper.GetString("loggregator-endpoint")))
+	LogDebug("Loggregator-ca-path: ", fmt.Sprintf("%s", viper.GetString("loggregator-ca-path")))
+	LogDebug("Loggregator-cert-path: ", fmt.Sprintf("%s", viper.GetString("loggregator-cert-path")))
+	LogDebug("Loggregator-key-path: ", fmt.Sprintf("%s", viper.GetString("loggregator-key-path")))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -9,11 +9,11 @@ type LoggregatorOptions struct {
 }
 
 type ConfigType struct {
-	Namespace           string `mapstructure:"namespace" yaml:"namespace"`
-	LoggregatorEndpoint string `mapstructure:"loggregator-endpoint" yaml:"loggregator-endpoint"`
-	LoggregatorCAPath   string `mapstructure:"loggregator-ca-path" yaml:"loggregator-ca-path"`
-	LoggregatorCertPath string `mapstructure:"loggregator-cert-path" yaml:"loggregator-cert-path"`
-	LoggregatorKeyPath  string `mapstructure:"loggregator-key-path" yaml:"loggregator-key-path"`
+	Namespace           string `mapstructure:"namespace"`
+	LoggregatorEndpoint string `mapstructure:"loggregator-endpoint"`
+	LoggregatorCAPath   string `mapstructure:"loggregator-ca-path"`
+	LoggregatorCertPath string `mapstructure:"loggregator-cert-path"`
+	LoggregatorKeyPath  string `mapstructure:"loggregator-key-path"`
 }
 
 func (conf ConfigType) GetLoggregatorOptions() LoggregatorOptions {

--- a/config/config.go
+++ b/config/config.go
@@ -9,11 +9,11 @@ type LoggregatorOptions struct {
 }
 
 type ConfigType struct {
-	Namespace           string `mapstructure:"namespace"`
-	LoggregatorEndpoint string `mapstructure:"loggregator-endpoint"`
-	LoggregatorCAPath   string `mapstructure:"loggregator-ca-path"`
-	LoggregatorCertPath string `mapstructure:"loggregator-cert-path"`
-	LoggregatorKeyPath  string `mapstructure:"loggregator-key-path"`
+	Namespace           string `mapstructure:"namespace" yaml:"namespace"`
+	LoggregatorEndpoint string `mapstructure:"loggregator-endpoint" yaml:"loggregator-endpoint"`
+	LoggregatorCAPath   string `mapstructure:"loggregator-ca-path" yaml:"loggregator-ca-path"`
+	LoggregatorCertPath string `mapstructure:"loggregator-cert-path" yaml:"loggregator-cert-path"`
+	LoggregatorKeyPath  string `mapstructure:"loggregator-key-path" yaml:"loggregator-key-path"`
 }
 
 func (conf ConfigType) GetLoggregatorOptions() LoggregatorOptions {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/viper v1.6.3
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0-20200404061942-2a93acf49b83
 	k8s.io/apimachinery v0.0.0-20200410010401-7378bafd8ae2
 	k8s.io/client-go v0.0.0-20200330143601-07e69aceacd6


### PR DESCRIPTION
Fixes #13

With this change, now we don't fail anymore if a config file is not provided:
```
$ ./binaries/eirini-loggregator-bridge                     
Namespace:  
Loggregator-endpoint:  
Loggregator-ca-path:  
Loggregator-cert-path:  
Loggregator-key-path:  
namespace is missing from configuration
```

With a config file, we keep reading it correctly:
```
$ ./binaries/eirini-loggregator-bridge --config config.yaml
Namespace:  default
Loggregator-endpoint:  ca_path
Loggregator-ca-path:  ca_path
Loggregator-cert-path:  ca_path
Loggregator-key-path:  ca_path
{"level":"info","ts":1587461901.3673894,"caller":"kubeconfig/getter.go:79","msg":" does not exist, using default kube config"}
```

while we allow now to setup configuration via environment variables and also override the config file:

```
$ NAMESPACE=foo ./binaries/eirini-loggregator-bridge --config config.yaml 
Namespace:  foo
Loggregator-endpoint:  ca_path
Loggregator-ca-path:  ca_path
Loggregator-cert-path:  ca_path
Loggregator-key-path:  ca_path
```

Note: `EIRINI_LOGGREGATOR_BRIDGE_LOGLEVEL=DEBUG` must be set to show the config values that are used 