### PR TITLE
feat: building docker image with local deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,28 @@ ARG DEBUG_TOOLS=false
 ARG KUBECTL_VERSION=v1.18.2
 ARG KUBECTL_ARCH=linux-amd64
 ARG KUBECTL_CHECKSUM=ed36f49e19d8e0a98add7f10f981feda8e59d32a8cb41a3ac6abdfb2491b3b5b3b6e0b00087525aa8473ed07c0e8a171ad43f311ab041dcc40f72b36fa78af95
-ADD . /eirini-loggregator-bridge
-WORKDIR /eirini-loggregator-bridge
+ARG GO111MODULE="on"
+
+ENV GO111MODULE $GO111MODULE
+WORKDIR /go/src/github.com/SUSE/eirini-loggregator-bridge
+
+# Cache go modules if possible
+ADD go.mod go.sum /go/src/github.com/SUSE/eirini-loggregator-bridge/
+RUN if [ "${GO111MODULE}" = "on" ] ; then go mod download ; fi
+
+ADD . /go/src/github.com/SUSE/eirini-loggregator-bridge/
 RUN git config --global user.name ${USER}
 RUN git config --global user.email ${EMAIL}
-RUN GO111MODULE=on go mod vendor
 RUN bin/build
 RUN if [ "$DEBUG_TOOLS" = "true" ] ; then \
     wget -O kubectl.tar.gz https://dl.k8s.io/$KUBECTL_VERSION/kubernetes-client-$KUBECTL_ARCH.tar.gz && \
     echo "$KUBECTL_CHECKSUM kubectl.tar.gz" | sha512sum --check --status && \
     tar xvf kubectl.tar.gz -C / && \
-    cp -f /kubernetes/client/bin/kubectl /eirini-loggregator-bridge/binaries/; fi
+    cp -f /kubernetes/client/bin/kubectl /go/src/github.com/SUSE/eirini-loggregator-bridge/binaries/; fi
+
+RUN mkdir -p tmp
+RUN chmod a+rwx tmp
 
 FROM $BASE_IMAGE
-COPY --from=build /eirini-loggregator-bridge/binaries/* /bin/
+COPY --from=build /go/src/github.com/SUSE/eirini-loggregator-bridge/binaries/* /bin/
 ENTRYPOINT ["/bin/eirini-loggregator-bridge"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,30 @@ In that case though you have to make sure your loggregator endpoint is accessibl
 from outside the cluster.
 
 
-## Debugging
+## Development
+
+### Building docker image with local dependencies
+
+The docker image can be built with:
+
+```
+make build-image
+```
+
+To use local dependencies (e.g. to use a locally modified `eirinix` for testing),
+update the go module dependencies as normal:
+
+```
+go mod edit -replace github.com/SUSE/eirinix=../eirinix
+```
+
+Then, to build the docker image:
+
+```
+VENDOR=on make build-image
+```
+
+### Debugging
 
 You can increase the log level of the tool by setting the `EIRINI_LOGGREGATOR_BRIDGE_LOGLEVEL`
 environment variable. Allowed values are: "DEBUG", "INFO", "WARN", "ERROR" (Default is "WARN")

--- a/bin/build-image
+++ b/bin/build-image
@@ -9,4 +9,10 @@ BASEDIR="$(cd "$(dirname "$0")/.." && pwd)"
 DOCKER_ORG="${DOCKER_ORG:-splatform/}"
 DOCKER_IMAGE="${DOCKER_IMAGE:-${DOCKER_ORG}eirini-loggregator-bridge:latest}"
 
-docker build --rm --no-cache -t "${DOCKER_IMAGE}" ${BASEDIR}
+build_arg=()
+if [ "${VENDOR}" = "on" ] ; then
+    GO111MODULE=on go mod vendor
+    build_arg+=( --build-arg "GO111MODULE=off" )
+fi
+
+docker build --rm --no-cache "${build_arg[@]}" -t "${DOCKER_IMAGE}" ${BASEDIR}


### PR DESCRIPTION
This allows opt-in building of the docker image with local dependencies (e.g. a locally forked eirinix).  This is useful so that local edits can be pulled in for development testing.

The default behaviour has not changed; this is opt-in only.

This is mostly inspired by the equivalent [in cf-operator](https://github.com/cloudfoundry-incubator/cf-operator/blob/master/docs/development.md#local-development-and-go-mod-replace).