### PR TITLE
Start watching for events from last resource version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	code.cloudfoundry.org/go-diodes v0.0.0-20180905200951-72629b5276e3 // indirect
 	code.cloudfoundry.org/go-loggregator v7.4.0+incompatible
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
-	github.com/SUSE/eirinix v0.2.1-0.20200420122346-85a6c535b0ad
+	github.com/SUSE/eirinix v0.2.1-0.20200430115824-abd5ac20bfd1
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,11 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/SUSE/eirinix v0.2.1-0.20200420122346-85a6c535b0ad h1:9Yad3p2oOkbl1GPELgULez5T1qIugRvp7y5m6DFLSJM=
 github.com/SUSE/eirinix v0.2.1-0.20200420122346-85a6c535b0ad/go.mod h1:B1ZBIXtf2NAqbtK+/f2VtZtC0rUaOsojK/SS5n4prc4=
+github.com/SUSE/eirinix v0.2.1-0.20200430071754-bd0b4840b388 h1:K3y8+GQa6ByAhL9uWpJefKLqP6WlDsC0EtL3ou/KMJY=
+github.com/SUSE/eirinix v0.2.1-0.20200430071754-bd0b4840b388/go.mod h1:B1ZBIXtf2NAqbtK+/f2VtZtC0rUaOsojK/SS5n4prc4=
+github.com/SUSE/eirinix v0.2.1-0.20200430093852-a7d1bc594c96 h1:j2+xgOLf7tiBCM/uSveunUITzLPxQf5zEUg+mcL/ldI=
+github.com/SUSE/eirinix v0.2.1-0.20200430093852-a7d1bc594c96/go.mod h1:B1ZBIXtf2NAqbtK+/f2VtZtC0rUaOsojK/SS5n4prc4=
+github.com/SUSE/eirinix v0.2.1-0.20200430115824-abd5ac20bfd1/go.mod h1:B1ZBIXtf2NAqbtK+/f2VtZtC0rUaOsojK/SS5n4prc4=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/podwatcher/podwatcher_test.go
+++ b/podwatcher/podwatcher_test.go
@@ -24,10 +24,8 @@ var _ = Describe("podwatcher", func() {
 		Context("when initializing", func() {
 			It("sets the config", func() {
 				pw := NewPodWatcher(config.ConfigType{Namespace: "test"})
-				cpw, ok := pw.(*PodWatcher)
-				Expect(ok).To(BeTrue())
-				Expect(cpw.Config).ToNot(BeNil())
-				Expect(cpw.Config.Namespace).To(Equal("test"))
+				Expect(pw.Config).ToNot(BeNil())
+				Expect(pw.Config.Namespace).To(Equal("test"))
 			})
 		})
 	})


### PR DESCRIPTION
It adds a new method to the PodWatcher(EnsureLogStream) which first gets the current RV( Resource Version)
of the PodList, and then ensure that the current pods in the namespace are tracked.

This avoid races as we get the list of pods after getting the initial RV, so we are sure
to process all the events that happened meanwhile we set up the monitoring goroutines.

Also in this way we keep streaming logs of pods that are already in the namespace if the component
get restarted.

See: https://github.com/SUSE/eirinix/pull/38