### PR TITLE
fix: podwatcher: only list wanted ns initially

### DIFF
--- a/podwatcher/podwatcher.go
+++ b/podwatcher/podwatcher.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/SUSE/eirini-loggregator-bridge/logger"
 	eirinix "github.com/SUSE/eirinix"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -254,7 +253,7 @@ func (pw *PodWatcher) EnsureLogStream(manager eirinix.Manager) error {
 	}
 
 	// Get current RV
-	lw := cache.NewListWatchFromClient(client.RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(client.RESTClient(), "pods", pw.Config.Namespace, fields.Everything())
 	list, err := lw.List(metav1.ListOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
When starting the pod watcher, we will initially track all existing pods.  When we do so, make sure to only look for pods in the desired namespace, instead of all of them.  This avoids the error:

> `pods is forbidden: User "system:serviceaccount:kubecf:eirinix" cannot list resource "pods" in API group "" at the cluster scope`

This is a follow-up to #17.